### PR TITLE
fix(chen2021Fitness): don't hand out invalid JSON when there are not enough data to compute a fit

### DIFF
--- a/ext_models/chen2021Fitness/model.py
+++ b/ext_models/chen2021Fitness/model.py
@@ -19,8 +19,8 @@ def fit(
     # adapt the data to the required format
     x = t
     x = sm.add_constant(x)
-    y = np.column_stack((k, n-k))
-    
+    y = np.column_stack((k, n - k))
+
     # estimate the model
     model = sm.GLM(y, x, family=sm.families.Binomial(link=sm.families.links.logit())).fit(disp=0)
 
@@ -32,6 +32,10 @@ def fit(
 
     # take the MLE of the parameters as the functions of the MLE of beta0, beta
     beta0, beta1 = model.params
+
+    if beta1 == 0:
+        raise ValueError("Cannot compute fit: beta1 is zero. Did you supply enough data points?")
+
     t0, a, fd, fc = -beta0 / beta1, \
                     beta1, \
                     np.exp(beta1 * generation_time) - 1, \

--- a/ext_models/chen2021Fitness/server.py
+++ b/ext_models/chen2021Fitness/server.py
@@ -6,5 +6,8 @@ app = Flask(__name__)
 
 
 @app.route("/", methods=["POST"])
-def without_prediction() -> Dict:
-    return process(request.json)
+def without_prediction():
+    try:
+        return process(request.json)
+    except Exception as e:
+        return {"error": str(e)}, 500

--- a/src/main/kotlin/ch/ethz/covspectrum/controller/ExceptionHandler.kt
+++ b/src/main/kotlin/ch/ethz/covspectrum/controller/ExceptionHandler.kt
@@ -1,0 +1,36 @@
+package ch.ethz.covspectrum.controller
+
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.ControllerAdvice
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.client.HttpStatusCodeException
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler
+
+@ControllerAdvice
+class ExceptionHandler : ResponseEntityExceptionHandler() {
+    @ExceptionHandler(Throwable::class)
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    fun handleUnexpectedException(e: Throwable): ResponseEntity<ErrorResponse> {
+        return ResponseEntity(
+            ErrorResponse(
+                HttpStatus.INTERNAL_SERVER_ERROR.value(),
+                HttpStatus.INTERNAL_SERVER_ERROR.name,
+                e.message ?: "An unexpected error occurred"
+            ),
+            HttpStatus.INTERNAL_SERVER_ERROR
+        )
+    }
+
+    @ExceptionHandler(HttpStatusCodeException::class)
+    fun handleBadRequestException(e: HttpStatusCodeException): ResponseEntity<String> {
+        return ResponseEntity(e.responseBodyAsString, e.statusCode)
+    }
+}
+
+data class ErrorResponse(
+    val status: Int,
+    val error: String,
+    val message: String
+)


### PR DESCRIPTION
Some values were NaN or Infinity, which are no valid JSON tokens. Instead throw an error.

resolves #41

This PR tries to be minimally invasive, as this repo is mostly in maintenance mode. I only added what is necessary to fix the issue. As this repo has no test coverage, I don't want to risk more than necessary.

How I tested this locally:
* I had to update the dependencies in the model to run the Python code. My `requirements.txt` looks as follows:
```
click==7.1.2
Flask==1.1.2
gunicorn==20.0.4
itsdangerous==1.1.0
Jinja2==2.11.3
MarkupSafe==1.1.1
numpy==1.22.3
pandas==1.4
patsy==0.5.6
python-dateutil==2.8.1
pytz==2021.1
scipy==1.8.0
six==1.15.0
statsmodels==0.14.4
Werkzeug==1.0.1
```
* Change `MODEL_ENDPOINT = "http://localhost:7070"`
https://github.com/GenSpectrum/cov-spectrum-server/blob/f981d5ad9c05c358867193012d03ab89fcb12e90/src/main/kotlin/ch/ethz/covspectrum/controller/Chen2021FitnessController.kt#L15
* Run the Kotlin code with env variables `COV_SPECTRUM_DB_USERNAME=dummy;COV_SPECTRUM_DB_PASSWORD=dummy;COV_SPECTRUM_JWT_TOKEN_LIFETIME_SECONDS=10`
* Comment out the flyway migration
https://github.com/GenSpectrum/cov-spectrum-server/blob/f981d5ad9c05c358867193012d03ab89fcb12e90/src/main/kotlin/ch/ethz/covspectrum/CovSpectrumServerApplication.kt#L15-L16
* Run the code, check which class complains about missing env variables, comment out the whole class, run the code...